### PR TITLE
Update jwt_tool.py

### DIFF
--- a/jwt_tool.py
+++ b/jwt_tool.py
@@ -1323,6 +1323,8 @@ def rejigToken(headDict, paylDict, sig):
             claimnum += 1
     if expiredtoken:
         cprintc("[-] TOKEN IS EXPIRED!", "red")
+    if 'exp' not in comparestamps:
+        cprintc("[-] Token does not have an expiry set.", "red")
     cprintc("\n----------------------\nJWT common timestamps:\niat = IssuedAt\nexp = Expires\nnbf = NotBefore\n----------------------\n", "white")
     if args.targeturl and not args.crack and not args.exploit and not args.verify and not args.tamper and not args.sign:
         cprintc("[+] Sending token", "cyan")


### PR DESCRIPTION
Simple check to ensure that the jwt actually has an expiry claim, otherwise it would be valid forever / until it is revoked.

This was a finding on a web app assessment where the token was issued with no expiry at all and jwt_tool did not flag this.

All tokens should have an expiry set.